### PR TITLE
feat: Run PACTA from Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /target
-src/*.tar
+*.tar

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +131,53 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c27cdf28c0f604ba3f512b0c9a409f8de8513e4816705deb0498b627e7c3a3fd"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a9f1ab5e9f01a9b81f202e8562eb9a10de70abf9eaeac1be465c28b75aa4aa"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "core-foundation"
@@ -236,6 +332,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +439,17 @@ name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "itoa"
@@ -510,6 +623,7 @@ dependencies = [
 name = "pacta-cli"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "reqwest",
  "tokio",
 ]
@@ -762,6 +876,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +1037,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.0", features = ["derive"] }
 reqwest = "0.11"
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # pacta-cli
+
+This is a simple wrapper around the [PACTA for Investors Docker image](https://ghcr.io/rmi-pacta/workflow.transition.monitor), that allows users to easily run PACTA from the command line. 
+
+## Usage
+
+This repository assumes existing knowledge of running PACTA, and is mainly intended for internal RMI users. 
+
+To use it, you must have:
+* A local copy of prepared PACTA input data, with .sqlite prepared datasets
+* A local working directory, containing the usual `00_Log_File`, `10_Parameter_File`, etc... directory structure
+* A working installation of Rust and Cargo
+
+With these, simply clone the repo can call:
+``` bash
+cargo run -- <PORTFOLIO_NAME> <PACTA_DATA_PATH> <WORKING_DIR_PATH>
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,28 @@
+#![allow(unused)]
+
+use clap::Parser;
 use reqwest::Url;
 use std::process::Command;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt; // Import AsyncWriteExt trait
 
+/// Search for a pattern in a file and display the lines that contain it.
+#[derive(Parser)]
+struct Cli {
+    /// The portfolio to run
+    portfolio_name: String,
+    /// The path to the file to read
+    data_path: std::path::PathBuf,
+    // The path to the working directory
+    working_dir: std::path::PathBuf,
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Parse the command line arguments
+    let args = Cli::parse();
     // Define the image URL
-    let image_url = Url::parse("https://ghcr.io/jonashackt/hello-world:latest")?;
+    let image_url = Url::parse("https://ghcr.io/rmi-pacta/workflow.transition.monitor:latest")?;
 
     // Download the image tarball
     let response = reqwest::get(image_url).await?;
@@ -24,7 +40,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Run a Docker container to display ASCII art
     Command::new("docker")
-        .args(&["run", "--rm", "hello-world"])
+        .args(&[
+            "run",
+            "-it",
+            "--rm",
+            "--mount",
+            format!(
+                "type=bind,source={},target=/bound/working_dir",
+                args.working_dir.display()
+            )
+            .as_str(),
+            "--mount",
+            format!(
+                "type=bind,source={},target=/pacta-data",
+                args.data_path.display()
+            )
+            .as_str(),
+            "ghcr.io/rmi-pacta/workflow.transition.monitor:latest",
+            "/bound/bin/run-r-scripts",
+            //format!("/bound/bin/run-r-scripts {}", args.portfolio_name).as_str(),
+        ])
         .status()?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .as_str(),
             "ghcr.io/rmi-pacta/workflow.transition.monitor:latest",
             "/bound/bin/run-r-scripts",
-            //format!("/bound/bin/run-r-scripts {}", args.portfolio_name).as_str(),
+            args.portfolio_name.as_str(),
         ])
         .status()?;
 


### PR DESCRIPTION
Rust program now accepts three command line arguments:
- `<PORTFOLIO_NAME>`, a string with the portfolio name
- `<DATA_PATH>`, a path to a `pacta-data` directory
- `<WORKING_DIR>`, a path to a `working_dir` directory

It then pulls the `latest` tag of the `ghcr.io/rmi-pacta/workflow.transition.monitor` docker image, and runs `/bound/bin/run-r-scripts $portfolio_name` 
