### PR TITLE
feat: Install image.tar in tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "reqwest",
+ "tempfile",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
 reqwest = "0.11"
+tempfile = "3.2"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Before: Running this program would leave a `image.tar` artifact
Now: The docker image is loaded into a tempfile that is removed once it falls from scope