### PR TITLE
Reference new `worfklow.pacta` image

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse the command line arguments
     let args = Cli::parse();
     // Define the image URL
-    let image_url = Url::parse("https://ghcr.io/rmi-pacta/workflow.transition.monitor:latest")?;
+    let image_url = Url::parse("https://ghcr.io/rmi-pacta/workflow.pacta:latest")?;
 
     let image_data = download_image(image_url).await?;
 
@@ -55,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "--rm",
             "--mount",
             format!(
-                "type=bind,source={},target=/bound/working_dir",
+                "type=bind,source={},target=/workflow.pacta/working_dir",
                 args.working_dir.display()
             )
             .as_str(),
@@ -65,8 +65,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 args.data_path.display()
             )
             .as_str(),
-            "ghcr.io/rmi-pacta/workflow.transition.monitor:latest",
-            "/bound/bin/run-r-scripts",
+            "ghcr.io/rmi-pacta/workflow.pacta:latest",
+            "/run-pacta.sh",
             args.portfolio_name.as_str(),
         ])
         .status()?;


### PR DESCRIPTION
This PR updates the rust `pacta-cli` to reference the new https://github.com/RMI-PACTA/workflow.pacta repository. 

Blocked by https://github.com/RMI-PACTA/workflow.pacta/issues/29

<img width="1385" alt="Screenshot 2024-01-09 at 12 31 17" src="https://github.com/jdhoffa/pacta-cli/assets/8741309/a83a047a-478b-49b9-92e5-ffa87a979060">

TODO: 
- [ ] Ensure works with `.json` style parameter files
- [ ] Update `README.md` to ensure works with no `10_Log...` directory structure
- [ ] Re-release on `homebrew`